### PR TITLE
Bugfix/48 missing appender tasklogfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- register missing appenders in logging configuration 
 
 ## [v3.23.0-3] - 2020-07-24
 ### Changed

--- a/resources/logback.xml.tpl
+++ b/resources/logback.xml.tpl
@@ -56,5 +56,6 @@
     <root level="${root.level:-{{ .Config.GetOrDefault "logging/root" "WARN"}}}">
         <appender-ref ref="console"/>
         <appender-ref ref="logfile"/>
-    </root>
+        <appender-ref ref="tasklogfile"/>
+</root>
 </configuration>

--- a/resources/logback.xml.tpl
+++ b/resources/logback.xml.tpl
@@ -6,7 +6,12 @@
 
     <jmxConfigurator/>
 
+    <appender name="osgi" class="org.ops4j.pax.logging.logback.appender.PaxAppenderDelegate">
+        <filter class="org.sonatype.nexus.pax.logging.NexusLogFilter" />
+    </appender>
+
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="org.sonatype.nexus.pax.logging.NexusLogFilter" />
         <encoder>
             <pattern>%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %mdc{userId:-*SYSTEM} %c - %m%n</pattern>
         </encoder>
@@ -20,10 +25,24 @@
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${karaf.data}/log/nexus-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
-            <totalSizeCap>10MB</totalSizeCap>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>20MB</totalSizeCap>
         </rollingPolicy>
         <filter class="org.sonatype.nexus.pax.logging.NexusLogFilter" />
+    </appender>
+
+    <appender name="clusterlogfile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>${karaf.data}/log/nexus_cluster.log</File>
+        <Append>true</Append>
+        <encoder class="org.sonatype.nexus.pax.logging.NexusLayoutEncoder">
+            <pattern>%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %node %mdc{userId:-*SYSTEM} %c - %m%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${karaf.data}/log/nexus_cluster-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>20MB</totalSizeCap>
+        </rollingPolicy>
+        <filter class="org.sonatype.nexus.pax.logging.ClusterLogFilter" />
     </appender>
 
     <appender name="tasklogfile" class="ch.qos.logback.classic.sift.SiftingAppender">
@@ -33,7 +52,8 @@
             <defaultValue>unknown</defaultValue>
         </discriminator>
         <sift>
-            <appender name="taskAppender" class="ch.qos.logback.core.ConsoleAppender">
+            <appender name="taskAppender" class="ch.qos.logback.core.FileAppender">
+                <file>${karaf.data}/log/tasks/${taskIdAndDate}.log</file>
                 <encoder class="org.sonatype.nexus.pax.logging.NexusLayoutEncoder">
                     <pattern>%d{"yyyy-MM-dd HH:mm:ss,SSSZ"} %-5p [%thread] %node %mdc{userId:-*SYSTEM} %c - %m%n</pattern>
                 </encoder>
@@ -41,21 +61,43 @@
         </sift>
     </appender>
 
+    <appender name="auditlogfile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>${karaf.data}/log/audit/audit.log</File>
+        <Append>true</Append>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+        <filter class="org.sonatype.nexus.pax.logging.AuditLogFilter"/>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${karaf.data}/log/audit/audit-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>20MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="auditlog" additivity="false">
+        <appender-ref ref="auditlogfile"/>
+    </logger>
+
     <appender name="metrics" class="org.sonatype.nexus.pax.logging.InstrumentedAppender"/>
 
-    <logger name="org.eclipse.jetty.webapp" level="{{ .Config.GetOrDefault "logging/root" "WARN"}}"/>
-    <logger name="org.eclipse.jetty.webapp.StandardDescriptorProcessor" level="{{ .Config.GetOrDefault "logging/root" "WARN"}}"/>
+    <logger name="org.eclipse.jetty.webapp" level="${root.level:-{{ .Config.GetOrDefault "logging/root" "WARN"}}}"/>
+    <logger name="org.eclipse.jetty.webapp.StandardDescriptorProcessor" level="${root.level:-{{ .Config.GetOrDefault "logging/root" "WARN"}}}"/>
 
-    <logger name="org.apache.aries" level="{{ .Config.GetOrDefault "logging/root" "WARN"}}"/>
-    <logger name="org.apache.felix" level="{{ .Config.GetOrDefault "logging/root" "WARN"}}"/>
-    <logger name="org.apache.karaf" level="{{ .Config.GetOrDefault "logging/root" "WARN"}}"/>
+    <logger name="org.apache.aries" level="${root.level:-{{ .Config.GetOrDefault "logging/root" "WARN"}}}"/>
+    <logger name="org.apache.felix" level="${root.level:-{{ .Config.GetOrDefault "logging/root" "WARN"}}}"/>
+    <logger name="org.apache.karaf" level="${root.level:-{{ .Config.GetOrDefault "logging/root" "WARN"}}}"/>
 
     <include file="${karaf.data}/etc/logback/logback-overrides.xml" optional="true"/>
 
-    <!-- root.level enters as environment variable via the logback-overrides.xml -->
     <root level="${root.level:-{{ .Config.GetOrDefault "logging/root" "WARN"}}}">
+        <appender-ref ref="osgi"/>
         <appender-ref ref="console"/>
         <appender-ref ref="logfile"/>
+        <appender-ref ref="clusterlogfile"/>
         <appender-ref ref="tasklogfile"/>
-</root>
+        <appender-ref ref="metrics"/>
+    </root>
 </configuration>
+
+


### PR DESCRIPTION
### Changed
- Fixes errors in logging of tasks see issue #48 by adding missing appenders in `logback.xml.tpl`

### Test Case
- Set dogu log level to `INFO`
- Execute the `Cleanup service` task in [administration -> tasks (last item)]
- The logs should look similar to the output below:
![Selection_587](https://user-images.githubusercontent.com/10109246/92108926-67546080-ede8-11ea-84aa-df1c5298fd67.png)

