### PR TITLE
Remove nexus admin password from environment variables 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Remove nexus admin password from environment variable. Now, the password is passed via enviroment variable passing only to the respective tools (#59)
+
 ## [v3.28.1-1] - 2020-11-16
 ### Changed
 - Upgrade Nexus to 3.28.1; #57

--- a/dogu.json
+++ b/dogu.json
@@ -74,6 +74,22 @@
           "ERROR"
         ]
       }
+    },
+    {
+      "Name": "container_config/memory_limit",
+      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description":"Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
     }
   ],
   "HealthChecks": [

--- a/resources/claim.sh
+++ b/resources/claim.sh
@@ -11,8 +11,6 @@ fi
 ONCE_LOCK="/var/lib/nexus/claim.once"
 
 export NEXUS_USER="admin"
-NEXUS_PASSWORD=$(doguctl config -e "admin_password")
-export NEXUS_PASSWORD
 # NEXUS_SERVER is already set in Dockerfile
 
 function claim() {
@@ -20,8 +18,15 @@ function claim() {
   LOCK="${2}"
   PLAN=$(mktemp)
   if doguctl config claim/"${CLAIM}" > "${PLAN}"; then
+    echo "Getting current admin password"
+    local nexusPassword
+    nexusPassword=$(doguctl config -e "admin_password")
+
     echo "exec claim ${CLAIM}"
-    nexus-claim plan -i "${PLAN}" -o "-" | nexus-claim apply -i "-"
+    NEXUS_PASSWORD="${nexusPassword}" \
+      nexus-claim plan -i "${PLAN}" -o "-" | \
+    NEXUS_PASSWORD="${nexusPassword}" \
+      nexus-claim apply -i "-"
 
     if [[ "${LOCK}" != "" ]]; then
       echo 1 > "${ONCE_LOCK}"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -290,15 +290,17 @@ fi
 echo "writing admin_group_last to etcd"
 doguctl config admin_group_last "${CES_ADMIN_GROUP}"
 
+nexusPassword=$(doguctl config -e "admin_password")
+
 echo "importing HTTP/S proxy settings from registry"
-NEXUS_PASSWORD=$(doguctl config -e "admin_password") \
+NEXUS_PASSWORD="${nexusPassword}" \
   nexus-scripting execute --file-payload "${NEXUS_WORKDIR}/resources/nexusConfParameters.json" "${NEXUS_WORKDIR}/resources/proxyConfiguration.groovy"
 
 echo "configuring carp server"
 doguctl template /etc/carp/carp.yml.tpl "${NEXUS_DATA_DIR}/carp.yml"
 
 echo "starting carp in background"
-NEXUS_PASSWORD="$(doguctl config -e "admin_password")" \
+NEXUS_PASSWORD="${nexusPassword}" \
   nexus-carp -logtostderr "${NEXUS_DATA_DIR}/carp.yml" &
 NEXUS_CARP_PID=$!
 

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -116,13 +116,17 @@ function configureNexusAtFirstStart() {
 
 function configureNexusAtSubsequentStart() {
   if [ -f "${NEXUS_WORKDIR}/resources/nexusConfigurationSubsequentStart.groovy" ] && [ -f "${NEXUS_WORKDIR}/resources/nexusConfParameters.json.tpl" ]; then
+    echo "Getting current admin password"
+    local nexusPassword
+    nexusPassword=$(doguctl config -e "admin_password")
+
     echo "Rendering nexusConfParameters template"
     doguctl template "${NEXUS_WORKDIR}/resources/nexusConfParameters.json.tpl" \
       "${NEXUS_WORKDIR}/resources/nexusConfParameters.json"
 
-    # uses NEXUS_PASSWORD set by exportNexusPasswordFromEtcd
     echo "Executing nexusConfigurationSubsequentStart script"
-    nexus-scripting execute \
+    NEXUS_PASSWORD="${nexusPassword}" \
+      nexus-scripting execute \
       --file-payload "${NEXUS_WORKDIR}/resources/nexusConfParameters.json" \
       "${NEXUS_WORKDIR}/resources/nexusConfigurationSubsequentStart.groovy"
   else
@@ -182,12 +186,6 @@ function waitForHealthEndpointAtSubsequentStart() {
   waitForHealthEndpoint "$1" "$(doguctl config -e admin_password)"
 }
 
-function exportNexusPasswordFromEtcd() {
-  echo "Getting current admin password"
-  NEXUS_PASSWORD=$(doguctl config -e admin_password)
-  export NEXUS_PASSWORD=${NEXUS_PASSWORD}
-}
-
 function terminateNexusAndNexusCarp() {
   echo "kill nexus"
   kill -TERM "$NEXUS_PID" || true
@@ -202,7 +200,15 @@ function terminateNexusAndNexusCarp() {
 function installDefaultDockerRegistry() {
   echo "Installing default docker registry"
   export NEXUS_SERVER="http://localhost:8081/nexus"
-  nexus-claim plan -i /defaultDockerRegistry.hcl -o "-" | nexus-claim apply -i "-"
+
+  echo "Getting current admin password"
+  local nexusPassword
+  nexusPassword=$(doguctl config -e "admin_password")
+
+  NEXUS_PASSWORD="${nexusPassword}" \
+    nexus-claim plan -i /defaultDockerRegistry.hcl -o "-" | \
+  NEXUS_PASSWORD="${nexusPassword}" \
+    nexus-claim apply -i "-"
 }
 
 function renderLoggingConfig() {
@@ -261,9 +267,6 @@ if [[ "$(doguctl config successfulInitialConfiguration)" != "true" ]]; then
   echo "Configuring Nexus for first start..."
   configureNexusAtFirstStart
 
-  echo "Exporting nexus password..."
-  exportNexusPasswordFromEtcd
-
   # Install default docker registry if not prohibited by etcd key
   if "$(doguctl config --default true installDefaultDockerRegistry)" != "false"; then
     installDefaultDockerRegistry
@@ -272,11 +275,6 @@ if [[ "$(doguctl config successfulInitialConfiguration)" != "true" ]]; then
   doguctl config successfulInitialConfiguration true
 
 else
-
-  # needs to be called before configureNexusAtSubsequentStart because it sets
-  # NEXUS_PASSWORD env var
-  echo "Exporting nexus password..."
-  exportNexusPasswordFromEtcd
 
   echo "Starting Nexus..."
   startNexus
@@ -293,13 +291,15 @@ echo "writing admin_group_last to etcd"
 doguctl config admin_group_last "${CES_ADMIN_GROUP}"
 
 echo "importing HTTP/S proxy settings from registry"
-nexus-scripting execute --file-payload "${NEXUS_WORKDIR}/resources/nexusConfParameters.json" "${NEXUS_WORKDIR}/resources/proxyConfiguration.groovy"
+NEXUS_PASSWORD=$(doguctl config -e "admin_password") \
+  nexus-scripting execute --file-payload "${NEXUS_WORKDIR}/resources/nexusConfParameters.json" "${NEXUS_WORKDIR}/resources/proxyConfiguration.groovy"
 
 echo "configuring carp server"
 doguctl template /etc/carp/carp.yml.tpl "${NEXUS_DATA_DIR}/carp.yml"
 
 echo "starting carp in background"
-nexus-carp -logtostderr "${NEXUS_DATA_DIR}/carp.yml" &
+NEXUS_PASSWORD="$(doguctl config -e "admin_password")" \
+  nexus-carp -logtostderr "${NEXUS_DATA_DIR}/carp.yml" &
 NEXUS_CARP_PID=$!
 
 echo "starting claim tool"


### PR DESCRIPTION
Fixes #59:

The nexus admin password is read on demand and passed into the respective tools instead of exporting the password into a 
global environment variable.

 