### PR TITLE
Optimization of MaxHeapSize with Docker-based memory limiting capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the PlantUML process inside the container via `cesapp edit-conf`  (#61)
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the Nexus process inside the container via `cesapp edit-conf`  (#61)
 
 ## [v3.28.1-2] - 2020-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optimized max heap size in limited dockerized environments (#61)
+
 ## [v3.28.1-2] - 2020-11-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Optimized max heap size in limited dockerized environments (#61)
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the PlantUML process inside the container via `cesapp edit-conf`  (#61)
 
 ## [v3.28.1-2] - 2020-11-27
 

--- a/dogu.json
+++ b/dogu.json
@@ -77,7 +77,7 @@
     },
     {
       "Name": "container_config/memory_limit",
-      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 1g of memory for nexus.",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
@@ -89,6 +89,24 @@
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/java_max_ram_percentage",
+      "Description":"Limits the heap stack size of the Nexus process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Nexus: 25%",
+      "Optional": true,
+      "Default": "25.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_min_ram_percentage",
+      "Description":"Limits the heap stack size of the Nexus process to the configured percentage of the available physical memory when the container has less than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Nexus: 50%",
+      "Optional": true,
+      "Default": "50.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
       }
     }
   ],

--- a/dogu.json
+++ b/dogu.json
@@ -77,7 +77,7 @@
     },
     {
       "Name": "container_config/memory_limit",
-      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 1500m of memory for nexus.",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 1g of memory for nexus.",
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"

--- a/dogu.json
+++ b/dogu.json
@@ -77,7 +77,7 @@
     },
     {
       "Name": "container_config/memory_limit",
-      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 1500m of memory for nexus.",
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -44,27 +44,41 @@ fi
 
 ### declaration of functions
 function setNexusVmoptionsAndProperties() {
-  cat <<EOF >"${NEXUS_WORKDIR}/bin/nexus.vmoptions"
-  -Xms1200M
-  -Xmx1200M
-  -XX:MaxDirectMemorySize=2G
-  -XX:+UnlockDiagnosticVMOptions
-  -XX:+UnsyncloadClass
-  -XX:+LogVMOutput
-  -XX:LogFile=${NEXUS_DATA_DIR}/log/jvm.log
-  -XX:-OmitStackTraceInFastThrow
-  -Djava.net.preferIPv4Stack=true
-  -Dkaraf.home=.
-  -Dkaraf.base=.
-  -Dkaraf.etc=etc/karaf
-  -Djava.util.logging.config.file=etc/karaf/java.util.logging.properties
-  -Dkaraf.data=${NEXUS_DATA_DIR}
-  -Djava.io.tmpdir=${NEXUS_DATA_DIR}/tmp
-  -Dkaraf.startLocalConsole=false
-  -Djavax.net.ssl.trustStore=${TRUSTSTORE}
-  -Djavax.net.ssl.trustStorePassword=changeit
-  -Djava.net.preferIPv4Stack=true
-  -Djava.endorsed.dirs=lib/endorsed
+  local VM_OPTIONS_FILE
+  VM_OPTIONS_FILE="${NEXUS_WORKDIR}/bin/nexus.vmoptions"
+
+  echo "Setting memory limits..."
+  if [[ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ]];  then
+    cat <<EOF >"$VM_OPTIONS_FILE"
+      -XX:MaxRAMPercentage=80.0
+      -XX:MinRAMPercentage=50.0
+EOF
+  else
+    cat <<EOF >"$VM_OPTIONS_FILE"
+      -Xms1200M
+      -Xmx1200M
+EOF
+  fi
+
+  cat <<EOF >>"$VM_OPTIONS_FILE"
+      -XX:MaxDirectMemorySize=2G
+      -XX:+UnlockDiagnosticVMOptions
+      -XX:+UnsyncloadClass
+      -XX:+LogVMOutput
+      -XX:LogFile=${NEXUS_DATA_DIR}/log/jvm.log
+      -XX:-OmitStackTraceInFastThrow
+      -Djava.net.preferIPv4Stack=true
+      -Dkaraf.home=.
+      -Dkaraf.base=.
+      -Dkaraf.etc=etc/karaf
+      -Djava.util.logging.config.file=etc/karaf/java.util.logging.properties
+      -Dkaraf.data=${NEXUS_DATA_DIR}
+      -Djava.io.tmpdir=${NEXUS_DATA_DIR}/tmp
+      -Dkaraf.startLocalConsole=false
+      -Djavax.net.ssl.trustStore=${TRUSTSTORE}
+      -Djavax.net.ssl.trustStorePassword=changeit
+      -Djava.net.preferIPv4Stack=true
+      -Djava.endorsed.dirs=lib/endorsed
 EOF
 }
 

--- a/spec/goss/goss.yaml
+++ b/spec/goss/goss.yaml
@@ -37,7 +37,6 @@ file:
   /opt/sonatype/nexus/bin/nexus.vmoptions:
     exists: true
     mode: "0770"
-    size: 644
     owner: nexus
     group: nexus
     filetype: file


### PR DESCRIPTION
Fixes #61

With Docker-based memory limiting capabilities, it is possible to restrict the memory for the Nexus-Dogu. Since version 10, Java can automatically detect container limits. However, Java generally only claims 25% of the physical memory (of the container) as the maximum heap size. This issue aims to optimize the maximum heap size while considering interferences with other possible programs in the container.

Set the MaxRamPercentage and MinRamPercentage to recommended values:
MaxRamPercentage=80.0 (considering nexux-claim) 
MinRamPercentage=50.0