### PR TITLE
Upgrade zlib package to fix CVE-2018-25032

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Upgrade zlib package to fix CVE-2018-25032; #100
 
 ## [v3.37.3-3] - 2022-03-09
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,11 @@ ENV NEXUS_VERSION=3.37.3-02 \
     SHA256_NEXUS_SCRIPTING="60c7f3d8a0c97b1d90d954ebad9dc07dbeb7927934b618c874b2e72295cafb48" \
     SHA256_NEXUS_CARP="f9a9d9f9efcabd27fb4df2544142000d5607c8feb9772e77f23239d7a6647458"
 
-RUN set -x \
+RUN set -o errexit \
+  && set -o nounset \
+  && set -o pipefail \
+  && apk update \
+  && apk upgrade \
   # add nexus user and group
   && addgroup -S -g 1000 nexus \
   && adduser -S -h /var/lib/nexus -s /bin/bash -G nexus -u 1000 nexus \


### PR DESCRIPTION
### Changed
- Upgrade zlib package to fix CVE-2018-25032

Resolves #100 