### PR TITLE
#109 Remove invalid java vm parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove java heap stack parameters when no memory limits are defined #109
 
 ## [v3.40.1-2] - 2022-08-19
 ### Added

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -51,9 +51,6 @@ EOF
     echo "Setting memory limits..."
     echo "-XX:MaxRAMPercentage=${MEMORY_LIMIT_MAX_PERCENTAGE}" >>"${VM_OPTIONS_FILE}"
     echo "-XX:MinRAMPercentage=${MEMORY_LIMIT_MIN_PERCENTAGE}" >>"${VM_OPTIONS_FILE}"
-  else
-    echo "-Xms1200M" >>"${VM_OPTIONS_FILE}"
-    echo "-Xmx1200M" >>"${VM_OPTIONS_FILE}"
   fi
 
   cat "${VM_OPTIONS_FILE}"


### PR DESCRIPTION
The limitation of the minimum and maximum stack sizes should only be considered when the user configures memory limits for the dogu.

Resolves #109 